### PR TITLE
use CACHE to be consistent with the rest of the extension code

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -317,8 +317,8 @@
             }
 
             $filename = sprintf(
-                "%s/cache/cacheabledatasource/%s_%s.xml",
-                MANIFEST,
+                "%s/cacheabledatasource/%s_%s.xml",
+                CACHE,
                 preg_replace("/^datasource/", '', get_class($datasource)),
                 md5($filename)
             );


### PR DESCRIPTION
so we can move the cache directory by setting `CACHE`.

The extension creates the cache directory relative to `CACHE` but creates the cache filename relative to `MANIFEST`.

